### PR TITLE
Switch from Glide to Go Modules

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -1,2 +1,0 @@
-package: github.com/swisscom/cf-sample-app-go
-import: []

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/swisscom/cf-sample-app-go
+
+go 1.12


### PR DESCRIPTION
See https://github.com/Masterminds/glide

> Go Modules
>
> The Go community is now using Go Modules to handle dependencies. Please consider using that instead of Glide. Glide is now mostly unmaintained.